### PR TITLE
save image as JPEG; use blob API

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,11 +335,12 @@ for (var i=0, len=sz.length; i<len; i++) {
 }
 
 function saveImage(){
-
-  var link = document.createElement('a');
-  link.download = filename;
-  link.href = document.getElementById('imageCanvas').toDataURL()
-  link.click();
+  document.getElementById('imageCanvas').toBlob(function (blob) {
+    var link = document.createElement('a');
+    link.download = filename;
+    link.href = URL.createObjectURL(blob);
+    link.click();
+  }, 'image/jpeg', 0.8);
 }
 
 document.getElementById("file-input").onchange = function(e) {


### PR DESCRIPTION
Hi @everestpipkin, thanks for your work on this!

This PR makes two related changes to the saving functionality:
* Images are stored as a JPEG rather than a PNG, providing much-reduced file sizes.
* The code now uses the [`toBlob()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) functionality rather than `toDataURL()` for notably better performance.

I hope these are helpful changes.