### PR TITLE
Mobile layout fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    box-sizing: border-box;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -113,6 +113,14 @@
     display: block;
     z-index: 3;
     font-size: 14px;
+    overflow: auto;
+    box-sizing: border-box;
+}
+
+@media (max-width: 800px) {
+    #imageScrubberInfo {
+        max-height: 85%;
+    }
 }
 
 #exifScrollDiv{


### PR DESCRIPTION
1. Stopped `#topBar` overflowing rightward due to its `box-sizing` and causing the dreaded horizontal scroll
   <img width="397" alt="Screen Shot 2020-05-31 at 14 19 09" src="https://user-images.githubusercontent.com/9437625/83360531-f9634d80-a34f-11ea-8037-edf91b4d310a.png">    

2. Made `#imageScrubberInfo` fully scrollable on small screens, e.g. iPhone 7 size