### PR TITLE
Adding info about offline usage to README and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The website works without an internet connection, and it's more secure to use th
 
 1. Turn on airplane mode after loading it - This way, no third-party services can transmit the images you upload. (Recommended for mobile)
 
-2. [Download](https://github.com/everestpipkin/image-scrubber/archive/master.zip) the tool from Github, and open index.html locally: This is the safest, but takes a little more effort and is harder to do on mobile.  By clicking the link, you will download a zip file containing all the files necessary to run this on your own system.  Extract, or unzip, the folder, and open the index.html file with a web browser of your choice, and use it using the instructions above.  
+2. [Download](https://github.com/everestpipkin/image-scrubber/archive/master.zip) the tool from Github, and open index.html locally: This is the safest, but takes a little more effort and is harder to do on mobile.  By clicking the link, you will download a zip file containing all the files necessary to run this on your own system.  Extract, or unzip, the folder, and open the index.html file with a web browser of your choice, and use it using the instructions above.  Just to be safe, still turn off data/internet before uploading any photos to the tool.
 
-The other option, if you're a command-line whiz with git setup, is to clone this repository.  The command to do this: 
+If you're a command-line whiz with git set up, you can clone this repository instead of downloading the zip.  The command to do so: 
 
     git clone https://github.com/everestpipkin/image-scrubber
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Dragging on the image will blur it. You can change your brush size and the inten
 
 **All processing happens directly in the browser- no information is stored or sent anywhere.** 
 
+**All processing happens directly in the browser- no information is stored or sent anywhere.** 
+
+The website works without an internet connection, and it's more secure to use this resource offline.  There are two ways to do this: 
+
+1. Turn on airplane mode after loading it - This way, no third-party services can transmit the images you upload. (Recommended for mobile)
+
+2. [Download] (https://github.com/everestpipkin/image-scrubber/archive/master.zip) the tool from Github, and open index.html locally: This is the safest, but takes a little more effort and is harder to do on mobile.  By clicking the link, you will download a zip file containing all the files necessary to run this on your own system.  Extract, or unzip, the folder, and open the index.html file with a web browser of your choice, and use it using the instructions above.  
+
+The other option, if you're a command-line whiz with git setup, is to clone this repository.  The command to do this: 
+
+    git clone https://github.com/everestpipkin/image-scrubber
 
 
 Bits of this code lifted and adapted from various jsfiddles and libraries --

--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Dragging on the image will blur it. You can change your brush size and the inten
 
 **All processing happens directly in the browser- no information is stored or sent anywhere.** 
 
-**All processing happens directly in the browser- no information is stored or sent anywhere.** 
-
 The website works without an internet connection, and it's more secure to use this resource offline.  There are two ways to do this: 
 
 1. Turn on airplane mode after loading it - This way, no third-party services can transmit the images you upload. (Recommended for mobile)
 
-2. [Download] (https://github.com/everestpipkin/image-scrubber/archive/master.zip) the tool from Github, and open index.html locally: This is the safest, but takes a little more effort and is harder to do on mobile.  By clicking the link, you will download a zip file containing all the files necessary to run this on your own system.  Extract, or unzip, the folder, and open the index.html file with a web browser of your choice, and use it using the instructions above.  
+2. [Download](https://github.com/everestpipkin/image-scrubber/archive/master.zip) the tool from Github, and open index.html locally: This is the safest, but takes a little more effort and is harder to do on mobile.  By clicking the link, you will download a zip file containing all the files necessary to run this on your own system.  Extract, or unzip, the folder, and open the index.html file with a web browser of your choice, and use it using the instructions above.  
 
 The other option, if you're a command-line whiz with git setup, is to clone this repository.  The command to do this: 
 

--- a/index.html
+++ b/index.html
@@ -278,6 +278,18 @@ You can select between painting over the image or blurring it out. Dragging on t
 
 <strong>All processing happens directly in the browser- no information is stored or sent anywhere.</strong>
 
+This website also works offline, and there are two such ways to use it. 
+
+The first is to turn on airplane mode (or turn off wifi/mobile data) before uploading any pictures. 
+
+The second (harder on mobile) is to (<a href="https://github.com/everestpipkin/image-scrubber/archive/master.zip">download</a> the repository, extract/unzip the folder, and run index.html in a web browser of your choice.  
+
+Alternatively, if you know how to use the git CLI and have it set up, you can clone this repo by using the following command: 
+git clone https://github.com/everestpipkin/image-scrubber 
+instead of downloading from the link.
+
+Once again, turn on airplane mode or turn off connectivity before actually using the tool.
+
 
 Bug reports or questions to: everest.pipkin@gmail.com
 


### PR DESCRIPTION
Added a quick guide to using the scrubber offline to index.html and the readme

Content is basically the same on both pages, suggesting that mobile users turn off data/connectivity before uploading pictures and that computer users either download the repo (link provided) or clone it (git command provided), and then run index.html locally.  

Thank you for your work!