### PR TITLE
Remove path from input filename, replace extension with .jpg

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,11 @@ for (var i=0, len=sz.length; i<len; i++) {
 function saveImage(){
   document.getElementById('imageCanvas').toBlob(function (blob) {
     var link = document.createElement('a');
-    link.download = filename;
+
+    var nameWithoutPath = filename.replace(/.*[\\/]([^\\/]+)$/, '$1');
+    var nameWithoutExtension = nameWithoutPath.replace(/\.[^.]*$/, '');
+
+    link.download = nameWithoutExtension + '.jpg';
     link.href = URL.createObjectURL(blob);
     link.click();
   }, 'image/jpeg', 0.8);


### PR DESCRIPTION
On pc, the filenames get mangled with the addition of C:\fakepath\ to the file path. This patch removes the path portion from the filename. It also replaces the file extension with .jpg, since that's the format the image is saved in. 

This should handle both forward and backslashes as well as filenames having no slashes and no file extensions. Only anything after the last dot in the filename is removed, if the filename has multiple dots  only the last part is replaced