### PR TITLE
Add zoom slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,11 @@ function populateBlurAmount(){
 
 function setZoom() {
     zoomScale = this.value / 100;
-    canvas.style.transform = "scale(" + zoomScale + ")";
+    // Zooms in on center, so we have to adjust image positioning
+    // 1/z is the portion visible, so (z-1)/z is the portion hidden
+    // half of that is lost above & left of the div, so translate by (z-1)/2z
+    var zoomTranslate = 100 * (zoomScale-1)/(2*zoomScale); // as a percentage
+    canvas.style.transform = "scale(" + zoomScale + ") translate(" + zoomTranslate + "%, " + zoomTranslate + "%)";
     setCursor();
 }
 

--- a/index.html
+++ b/index.html
@@ -66,6 +66,10 @@
 <div id="blurAmountDiv" class="topBarDiv"><center> Blur Radius<br>
   <input type="range" min="20" max="130" value="75" class="slider" id="blurAmount"></center>
 </div>
+
+<div id="zoomScaleDiv" class="topBarDiv"><center> Zoom<br>
+  <input type="range" min="100" max="200" value="100" class="slider" id="zoomScale"></center>
+</div>
 </div>
 
 <button id="about">About</button>
@@ -99,11 +103,13 @@ If you want other ways to cover your digital footprint, I've assembled a list of
 </div>
 
     <div id="exifInformationHolder"></div>
+    <div id="imageContainer">
     <canvas id="imageCanvas"></canvas>
     <canvas id="tempCanvas"></canvas>
     <canvas id="holderCanvas"></canvas>
     <canvas id="rotationCanvas"></canvas>
     <canvas id="blurredCanvas"></canvas>
+    </div>
 
     <script type="text/javascript" src="scripts/exif.js"></script>
     <script type="text/javascript" src="scripts/stackblur.js"></script>
@@ -133,6 +139,7 @@ var blurredCtx = blurredCanvas.getContext("2d");
 
 var brushSize = 50;
 var blurAmount = 50;
+var zoomScale = 1;
 
 //blur amount needs to be set for the size of the canvas ...
 //100 x 100 is arond 5, 2500 x 2500 is around 100
@@ -162,6 +169,9 @@ brushSizeDiv.onchange = populateBrushSize;
 var blurAmountDiv = document.getElementById("blurAmount");
 blurAmountDiv.onchange = populateBlurAmount;
 
+var zoomScaleDiv = document.getElementById("zoomScale");
+zoomScaleDiv.oninput = setZoom;
+
 function populateBrushSize(){
     brushSize = Math.floor(this.value * canvas.width/800);
     setCursor();
@@ -171,13 +181,18 @@ function populateBlurAmount(){
     blurAmount = Math.floor(this.value);
 }
 
+function setZoom() {
+    zoomScale = this.value / 100;
+    canvas.style.transform = "scale(" + zoomScale + ")";
+    setCursor();
+}
 
 function setCursor(){
 
     var cursorCanvas = document.createElement('canvas');
     var scaleX = canvas.getBoundingClientRect().width / canvas.width;
-    cursorCanvas.width = ((brushSize*2)*scaleX);
-    cursorCanvas.height = ((brushSize*2)*scaleX);
+    cursorCanvas.width = ((brushSize*2)*scaleX*zoomScale);
+    cursorCanvas.height = ((brushSize*2)*scaleX*zoomScale);
     var cursorCtx = cursorCanvas.getContext('2d');
 
     cursorCtx.beginPath();

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -37,6 +37,17 @@
     justify-content: center;
 }
 
+.topBarRadio{
+    width: 18vw;
+    height: 12vh;
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}
+
 
 #file-input{
     flex-direction: row;
@@ -112,7 +123,15 @@
     border: 0px solid #ccc;
     border-left: 0px solid #ccc;
     border-right: 0px solid #ccc;
+}
 
+#paintBlur{
+    width:100%;
+    height:3vh;
+}
+
+#paintBlur br{
+    display: none;
 }
 
 

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -1,12 +1,17 @@
-
-#imageCanvas{
+#imageContainer{
     position: absolute;
     top: 56%;
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
-    max-width: 100%;
-    max-height: 82%;
+    width: 100%;
+    height: 82%;
     z-index: -1;
+    overflow: auto;
+}
+
+#imageCanvas{
+    max-width: 100%;
+    max-height: 100%;
     cursor: crosshair;
 }
 

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -116,10 +116,10 @@
 }
 
 
-#imageCanvas{
+#imageContainer{
     position: absolute;
     top: 58%;
-    max-height: 75%;
+    height: 75%;
 }
 
 #continueButtonExif{


### PR DESCRIPTION
Addresses my suggestion in #17 (Open for feedback on the FR/other solutions, but it was pretty quick to code up so I decided to go ahead and write it.)
* Adds slider to the top bar
* Slightly rearranges top bar on mobile
* Adds scrolling and cursor adjust as necessary when zoomed

Comparison images:
* Without zoom ([mobile](https://imgur.com/grvl5rq), [desktop](https://imgur.com/k7pd9r5))
* With zoom ([mobile1](https://imgur.com/a03KQiQ), [mobile2](https://imgur.com/VVaqCHh), [desktop1](https://imgur.com/8hgsHFc), [desktop2](https://imgur.com/eeaXLpl))

Note that on mobile, this changes the image's vertical position from centered to just below the top bar. I could prevent this with margins, but then it caused the slider to zoom the margins as well. I'm happy to look into other workarounds if the UI change is undesirable.