### PR TITLE
Hover states, HTML and CSS trimming

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,21 +34,20 @@
 
 <div id="topBar">
 
-    <div id="drop-zone">
-        <div id="openDiv" class="topBarDiv" class="custom-file-open">
-            <label for="file-input" class="custom-file-open">
+    <div id="drop-zone" class="topBarDiv dropZone">
+            <label for="file-input" class="customFileOpen controlButton">
                 Open image 📂
             </label>
-            <input id="file-input" type="file"/></div>
+            <input id="file-input" type="file"/>
     </div>
 
-<a id="saveButton" onclick="saveImage(this)" class="topBarDiv"><center>Save image 💾</center></a>
+<a id="saveButton" onclick="saveImage(this)" class="topBarDiv controlButton">Save image 💾</a>
 
 
-<div id="rotate" class="topBarDiv"><center>Rotate Image ⤾</center></div>
+<div id="rotate" class="topBarDiv controlButton">Rotate Image ⤾</div>
 
 
-<div id="paintBlur" class="topBarDiv" class="custom-file-open"><center>
+<div id="paintBlur" class="topBarDiv" class="customFileOpen"><center>
 <form id="paintForm">
 <input type="radio" id="Paint" name="paintingAction" value="paint">
 <label for="Paint">Paint</label><br>

--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@
 <div id="topBar">
 
     <div id="drop-zone">
-        <div id="openDiv" class="topBarDiv" class="custom-file-open"><center>
-            <label for="file-input" class="custom-file-open"><center>
-                Open image 📂</center>
+        <div id="openDiv" class="topBarDiv" class="custom-file-open">
+            <label for="file-input" class="custom-file-open">
+                Open image 📂
             </label>
-            <input id="file-input" type="file"/></center></div>
+            <input id="file-input" type="file"/></div>
     </div>
 
 <a id="saveButton" onclick="saveImage(this)" class="topBarDiv"><center>Save image 💾</center></a>

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -12,13 +12,11 @@
 
 #topBar{
     width:100%;
-    height:12vh;
     border: 1px solid black;
     display: flex;
-    flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    box-sizing: border-box;
+    /* box-sizing: border-box; */
 }
 
 
@@ -41,10 +39,6 @@
     padding-top: 2px;
     cursor: pointer;
 
-}
-
-#openDiv{
-    padding-top: 2px;
 }
 
 #exifInformationHolder{
@@ -217,4 +211,14 @@ pre {
 
 .custom-file-open{
     cursor: copy;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 2px;
+}
+.custom-file-open:hover,
+.custom-file-open:focus {
+    background: #ccc;
 }

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -193,6 +193,7 @@ pre {
 .controlButton {
     cursor: pointer;
     height: 100%;
+    width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -13,32 +13,23 @@
 #topBar{
     width:100%;
     border: 1px solid black;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    /* box-sizing: border-box; */
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
 }
 
-
-.topBarDiv{
-    width: 18vw;
-    height: 12vh;
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
+.topBarDiv {
+    width: 100%;
+    height: 100%;
+    padding: 5px 0;
+    border-left: 2px solid #ccc;
     display: flex;
     align-items: center;
     justify-content: center;
+    box-sizing: border-box;
+    min-height: 8vh;
 }
-
-
-#file-input{
-    flex-direction: row;
-}
-
-#saveButton{
-    padding-top: 2px;
-    cursor: pointer;
-
+.topBarDiv.dropZone {
+    padding: 0;
 }
 
 #exifInformationHolder{
@@ -80,43 +71,37 @@
     box-sizing: border-box;
 }
 
+#imageScrubberInfo a:hover,
+#imageScrubberInfo a:focus {
+    background: #ff0;
+}
+
 
 @media (max-width: 800px) {
     #imageScrubberInfo {
         max-height: 75%;
     }
+    
+    #topBar {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    
+    .topBarDiv{
+        border: none;
+    }
 
+    #imageCanvas{
+        position: absolute;
+        top: 58%;
+        max-height: 75%;
+    }
 
- #topBar {
-    flex-wrap: wrap;
-    height:20vh;
-    align-items: flex-start;
-  }
-
-
-.topBarDiv{
-    width: 33vw;
-    height: 8vh;
-    max-height:10vh;
-    border: 0px solid #ccc;
-    border-left: 0px solid #ccc;
-    border-right: 0px solid #ccc;
-
-}
-
-
-#imageCanvas{
-    position: absolute;
-    top: 58%;
-    max-height: 75%;
-}
-
-#continueButtonExif{
-    position: absolute;
-    bottom: 10%;
-    left: 50%;
-    transform: translateX(-50%) translateY(-50%);
-}
+    #continueButtonExif{
+        position: absolute;
+        bottom: 10%;
+        left: 50%;
+        transform: translateX(-50%) translateY(-50%);
+    }
 }
 
 #exifScrollDiv{
@@ -205,20 +190,15 @@ pre {
 
 }
 
-#rotate{
-        cursor: pointer;
-}
-
-.custom-file-open{
-    cursor: copy;
-    width: 100%;
+.controlButton {
+    cursor: pointer;
     height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding-top: 2px;
+    position: relative;
 }
-.custom-file-open:hover,
-.custom-file-open:focus {
+.controlButton:hover,
+.controlButton:focus {
     background: #ccc;
 }

--- a/scripts/css.css
+++ b/scripts/css.css
@@ -203,3 +203,7 @@ pre {
 .controlButton:focus {
     background: #ccc;
 }
+
+.customFileOpen {
+    cursor: copy;
+}


### PR DESCRIPTION
* Added larger hit areas and hover states per #23 
* Removed [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center) `<center>` elements
* Trimmed CSS that duplicates browser defaults, restructured some CSS to deal with future additions more easily
* Standardized class names

Hoverstates look like this:
![hoverstates](https://user-images.githubusercontent.com/5344587/83526226-1b75e080-a4b4-11ea-9ed1-063b2eb56a4a.gif)

There's a good bit of change in the CSS so I'm happy to review if there are any conflicts, but I didn't see any when merging into the existing version or my PR at #18 . Let me know anything else that looks off - thanks!