### PR TITLE
Update Pastebin link on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ Bug reports or questions to: everest.pipkin@gmail.com
 
 Github repo at <a href="https://github.com/everestpipkin/image-scrubber" target="_blank">github.com/everestpipkin/image-scrubber</a>
 
-If you want other ways to cover your digital footprint, I've assembled a list of resources: via <a href="https://docs.google.com/document/d/1615pZB11BhsR0KtvyiXfzfMUBlxZi47HzzhWHIRpxwU/edit" target="_blank">Google Doc</a> or <a href="https://pastebin.com/TPgtvmVB" target="_blank">Pastebin</a>.
+If you want other ways to cover your digital footprint, I've assembled a list of resources: via <a href="https://docs.google.com/document/d/1615pZB11BhsR0KtvyiXfzfMUBlxZi47HzzhWHIRpxwU/edit" target="_blank">Google Doc</a> or <a href="https://pastebin.com/bLh5MQ05" target="_blank">Pastebin</a>.
     </pre>
         </div>
 


### PR DESCRIPTION
The [current Pastebin link](https://pastebin.com/TPgtvmVB) is going to a 404 page. Apparently it was taken down in February of last year for being "potentially harmful". I don't know what could be considered harmful about this content, but luckily I found a version on the Wayback Machine from a few months before it was deleted: https://web.archive.org/web/20231128122012/https://pastebin.com/TPgtvmVB

I copied the contents from the Wayback Machine copy into a new Pastebin here: https://pastebin.com/bLh5MQ05

This is the same link that has been updated in `index.html` for this PR.

Of course, Pastebin might do the same thing all over again. An alternative to Pastebin might be to have an `anonymize_your_footprint.txt` file in this repo with these contents and have the link go to the GitHub raw file. A side benefit to that solution is that others can collaborate on the file's contents in the same way as the rest of the code. If you'd prefer that approach, go ahead and close this PR and I can make a new one.